### PR TITLE
fix: add use_cache_branch and KV cache support to merged decoder (#1)

### DIFF
--- a/src/ElBruno.Whisper/Inference/WhisperInferenceSession.cs
+++ b/src/ElBruno.Whisper/Inference/WhisperInferenceSession.cs
@@ -5,15 +5,36 @@ namespace ElBruno.Whisper.Inference;
 
 /// <summary>
 /// ONNX Runtime inference session for Whisper encoder-decoder pipeline.
+/// Supports Optimum-style merged decoder with use_cache_branch and past key-value caching.
 /// </summary>
 internal sealed class WhisperInferenceSession : IDisposable
 {
     private readonly InferenceSession _encoderSession;
     private readonly InferenceSession _decoderSession;
+    private readonly int _numDecoderLayers;
+    private readonly int _encoderDimension;
+    private readonly bool _hasCacheBranch;
+    private readonly List<CacheSlotInfo> _cacheSlots;
     private bool _disposed;
 
-    public WhisperInferenceSession(string encoderPath, string decoderPath)
+    /// <summary>
+    /// Describes a past_key_value cache slot discovered from decoder model metadata.
+    /// Maps an input name (past_key_values.*) to its corresponding output name (present.*).
+    /// </summary>
+    private readonly record struct CacheSlotInfo(
+        string InputName,
+        string OutputName,
+        int[] MetadataShape);
+
+    public WhisperInferenceSession(
+        string encoderPath,
+        string decoderPath,
+        int numDecoderLayers = 4,
+        int encoderDimension = 384)
     {
+        _numDecoderLayers = numDecoderLayers;
+        _encoderDimension = encoderDimension;
+
         var options = new SessionOptions
         {
             GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
@@ -21,6 +42,32 @@ internal sealed class WhisperInferenceSession : IDisposable
 
         _encoderSession = new InferenceSession(encoderPath, options);
         _decoderSession = new InferenceSession(decoderPath, options);
+
+        _hasCacheBranch = _decoderSession.InputMetadata.ContainsKey("use_cache_branch");
+        _cacheSlots = DiscoverCacheSlots();
+    }
+
+    /// <summary>
+    /// Discover past_key_values inputs from decoder model metadata at construction time.
+    /// This makes the session work across all Whisper model sizes without hardcoding.
+    /// </summary>
+    private List<CacheSlotInfo> DiscoverCacheSlots()
+    {
+        var slots = new List<CacheSlotInfo>();
+
+        foreach (var kvp in _decoderSession.InputMetadata)
+        {
+            if (!kvp.Key.StartsWith("past_key_values.", StringComparison.Ordinal))
+                continue;
+
+            // past_key_values.0.decoder.key → present.0.decoder.key
+            var suffix = kvp.Key.Substring("past_key_values.".Length);
+            var outputName = "present." + suffix;
+
+            slots.Add(new CacheSlotInfo(kvp.Key, outputName, kvp.Value.Dimensions));
+        }
+
+        return slots;
     }
 
     /// <summary>
@@ -33,18 +80,13 @@ internal sealed class WhisperInferenceSession : IDisposable
     /// <returns>Generated token IDs</returns>
     public int[] Inference(float[] melSpectrogram, int[] initialTokens, int maxTokens, int eotToken)
     {
-        // 1. Run encoder
         var encoderHiddenStates = RunEncoder(melSpectrogram);
-
-        // 2. Run decoder autoregressively
         var tokens = RunDecoder(encoderHiddenStates, initialTokens, maxTokens, eotToken);
-
         return tokens;
     }
 
     private float[] RunEncoder(float[] melSpectrogram)
     {
-        // Input: input_features [1, 80, 3000]
         var inputTensor = new DenseTensor<float>(melSpectrogram, new[] { 1, 80, 3000 });
         var inputs = new List<NamedOnnxValue>
         {
@@ -52,69 +94,141 @@ internal sealed class WhisperInferenceSession : IDisposable
         };
 
         using var results = _encoderSession.Run(inputs);
-        var output = results.First().AsEnumerable<float>().ToArray();
-        
-        return output;
+        return results.First().AsEnumerable<float>().ToArray();
     }
 
     private int[] RunDecoder(float[] encoderHiddenStates, int[] initialTokens, int maxTokens, int eotToken)
     {
         var tokens = new List<int>(initialTokens);
-        
-        // Determine encoder hidden states shape from encoder output
-        // Typically [1, seq_len, hidden_dim] where seq_len is 1500 for 30s audio
-        // For whisper-tiny: hidden_dim = 384, seq_len = 1500
-        var hiddenDim = encoderHiddenStates.Length / 1500; // Assumes seq_len = 1500
-        var seqLen = encoderHiddenStates.Length / hiddenDim;
 
-        for (int i = 0; i < maxTokens; i++)
+        var hiddenDim = encoderHiddenStates.Length / 1500;
+        const int encoderSeqLen = 1500;
+
+        var encoderTensor = new DenseTensor<float>(
+            encoderHiddenStates,
+            new[] { 1, encoderSeqLen, hiddenDim }
+        );
+
+        // KV cache: maps present.* output name → (data, shape) for feeding back as past_key_values.*
+        Dictionary<string, (float[] Data, int[] Shape)>? kvCache = null;
+
+        for (int step = 0; step < maxTokens; step++)
         {
-            // Prepare decoder inputs
-            var inputIds = tokens.ToArray();
-            var inputIdsTensor = new DenseTensor<long>(
-                inputIds.Select(t => (long)t).ToArray(),
-                new[] { 1, inputIds.Length }
-            );
+            var isFirstStep = step == 0;
+            var useCacheBranch = !isFirstStep;
 
-            var encoderHiddenStatesTensor = new DenseTensor<float>(
-                encoderHiddenStates,
-                new[] { 1, seqLen, hiddenDim }
-            );
+            // First step: full initial sequence. Cached steps: only the last generated token.
+            long[] inputIds;
+            int seqLen;
+            if (isFirstStep)
+            {
+                inputIds = tokens.Select(t => (long)t).ToArray();
+                seqLen = inputIds.Length;
+            }
+            else
+            {
+                inputIds = new[] { (long)tokens[tokens.Count - 1] };
+                seqLen = 1;
+            }
 
             var decoderInputs = new List<NamedOnnxValue>
             {
-                NamedOnnxValue.CreateFromTensor("input_ids", inputIdsTensor),
-                NamedOnnxValue.CreateFromTensor("encoder_hidden_states", encoderHiddenStatesTensor)
+                NamedOnnxValue.CreateFromTensor("input_ids",
+                    new DenseTensor<long>(inputIds, new[] { 1, seqLen })),
+                NamedOnnxValue.CreateFromTensor("encoder_hidden_states", encoderTensor)
             };
 
-            // Run decoder
+            // Add use_cache_branch scalar bool if the merged decoder expects it
+            if (_hasCacheBranch)
+            {
+                decoderInputs.Add(NamedOnnxValue.CreateFromTensor("use_cache_branch",
+                    new DenseTensor<bool>(new[] { useCacheBranch }, new int[0])));
+            }
+
+            // Add past key-value cache inputs (empty on first step, cached on subsequent)
+            AddCacheInputs(decoderInputs, kvCache);
+
             using var results = _decoderSession.Run(decoderInputs);
-            
-            // Get logits (last token)
-            var logits = results.First().AsEnumerable<float>().ToArray();
-            
-            // Greedy decode: argmax of last token
-            var lastTokenLogits = new float[logits.Length / inputIds.Length];
-            var offset = (inputIds.Length - 1) * lastTokenLogits.Length;
-            Array.Copy(logits, offset, lastTokenLogits, 0, lastTokenLogits.Length);
-            
+
+            // Extract logits and greedy-decode the last token position
+            var logitsOutput = results.First(r => r.Name == "logits");
+            var logits = logitsOutput.AsEnumerable<float>().ToArray();
+            var vocabSize = logits.Length / seqLen;
+            var lastTokenLogits = new float[vocabSize];
+            Array.Copy(logits, (seqLen - 1) * vocabSize, lastTokenLogits, 0, vocabSize);
+
             var nextToken = ArgMax(lastTokenLogits);
-            
-            // Check for end of sequence
+
+            // Capture present.* outputs as cache for next step
+            kvCache = ExtractPresentOutputs(results);
+
             if (nextToken == eotToken)
                 break;
-            
+
             tokens.Add(nextToken);
         }
 
         return tokens.ToArray();
     }
 
+    /// <summary>
+    /// Adds past key-value tensors to decoder inputs.
+    /// First step (cache is null): provides zero-length tensors so the model graph is satisfied.
+    /// Subsequent steps: feeds cached present values from the previous step.
+    /// </summary>
+    private void AddCacheInputs(
+        List<NamedOnnxValue> inputs,
+        Dictionary<string, (float[] Data, int[] Shape)>? cache)
+    {
+        foreach (var slot in _cacheSlots)
+        {
+            if (cache != null && cache.TryGetValue(slot.OutputName, out var cached))
+            {
+                inputs.Add(NamedOnnxValue.CreateFromTensor(slot.InputName,
+                    new DenseTensor<float>(cached.Data, cached.Shape)));
+            }
+            else
+            {
+                // Empty cache: create zero tensor with dynamic dims resolved (batch=1, seq=0)
+                var shape = (int[])slot.MetadataShape.Clone();
+                for (int d = 0; d < shape.Length; d++)
+                {
+                    if (shape[d] < 0)
+                        shape[d] = d == 0 ? 1 : 0;
+                }
+
+                inputs.Add(NamedOnnxValue.CreateFromTensor(slot.InputName,
+                    new DenseTensor<float>(Array.Empty<float>(), shape)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Extracts present.* key-value outputs from decoder results for caching.
+    /// Copies tensor data so the results collection can be safely disposed.
+    /// </summary>
+    private static Dictionary<string, (float[] Data, int[] Shape)> ExtractPresentOutputs(
+        IDisposableReadOnlyCollection<DisposableNamedOnnxValue> results)
+    {
+        var cache = new Dictionary<string, (float[] Data, int[] Shape)>();
+
+        foreach (var result in results)
+        {
+            if (!result.Name.StartsWith("present.", StringComparison.Ordinal))
+                continue;
+
+            var tensor = result.AsTensor<float>();
+            cache[result.Name] = (tensor.ToArray(), tensor.Dimensions.ToArray());
+        }
+
+        return cache;
+    }
+
     private static int ArgMax(float[] values)
     {
         int maxIndex = 0;
         float maxValue = values[0];
-        
+
         for (int i = 1; i < values.Length; i++)
         {
             if (values[i] > maxValue)
@@ -123,7 +237,7 @@ internal sealed class WhisperInferenceSession : IDisposable
                 maxIndex = i;
             }
         }
-        
+
         return maxIndex;
     }
 

--- a/src/ElBruno.Whisper/WhisperClient.cs
+++ b/src/ElBruno.Whisper/WhisperClient.cs
@@ -65,7 +65,10 @@ public sealed class WhisperClient : IDisposable
 
         var encoderPath = Path.Combine(modelPath, "onnx", "encoder_model.onnx");
         var decoderPath = Path.Combine(modelPath, "onnx", "decoder_model_merged.onnx");
-        var inference = new WhisperInferenceSession(encoderPath, decoderPath);
+        var inference = new WhisperInferenceSession(
+            encoderPath, decoderPath,
+            options.Model.NumDecoderLayers,
+            options.Model.EncoderDimension);
 
         return new WhisperClient(options, audioProcessor, tokenizer, inference);
     }


### PR DESCRIPTION
## Summary

Fixes #1 — OnnxRuntimeException: Missing Input use_cache_branch in decoder

## Root Cause

The decoder_model_merged.onnx from onnx-community Whisper repos uses an Optimum-style merged decoder with an If node (optimum::if) that requires a use_cache_branch boolean input. WhisperInferenceSession.RunDecoder() was not providing this input or handling the past key-value cache.

## Changes

### WhisperInferenceSession.cs
- **use_cache_branch input**: First step sends false (no cache), subsequent steps send true (use cache)
- **KV cache handling**: Extracts present.* outputs and feeds them back as past_key_values.* inputs
- **Dynamic discovery**: Cache slot names/shapes discovered from model InputMetadata — works across all model sizes
- **Token optimization**: After first step, only passes the last generated token since cache holds context
- **Empty cache tensors**: First step provides properly-shaped zero tensors to satisfy model graph

### WhisperClient.cs
- Passes NumDecoderLayers and EncoderDimension from WhisperModelDefinition to inference session constructor

## Verification
- Build: 0 errors
- Tests: 77/77 passing
