### PR TITLE
feat: add optional timestamp support for Whisper transcription (#12)

### DIFF
--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -46,3 +46,20 @@
 - All 109 tests passing with fix applied
 - Test infrastructure ready for CI/CD pipeline
 - Key decision documented: ONNX input tensor rank must match model declaration exactly
+
+### 2026-04-15 - Timestamp support tests (Issue #12)
+- **Action:** Wrote comprehensive tests for Ripley's timestamp implementation
+- **New files created:**
+  - `TranscriptionSegmentTests.cs`: 14 tests — properties, record equality, hash code, ToString, `with` expression, sealed check
+  - `Tokenizer/WhisperTokenizerTimestampTests.cs`: 22 tests — IsTimestampToken boundary (50363=false, 50364=true), GetTimestamp known values (0.00s, 0.02s, 1.00s), DecodeWithTimestamps segment extraction, special token skipping, trailing text handling, empty segment skipping
+  - `testdata/tokenizer/test-tokenizer.json`: Minimal tokenizer vocab for unit testing without real model
+- **Existing files updated:**
+  - `WhisperOptionsTests.cs`: +3 tests for EnableTimestamps (default false, set true, toggle back)
+  - `TranscriptionResultTests.cs`: +6 tests for Segments property (default null, set list, empty list, IReadOnlyList type, timestamp data)
+  - `ElBruno.Whisper.Tests.csproj`: Added tokenizer testdata content link
+- **Total:** 171 tests passing (was 126), 45 new tests added
+- **Edge cases discovered:**
+  - DecodeWithTimestamps handles trailing text (start timestamp but no end) by emitting segment with start=end
+  - Empty segments (two timestamps with no text between) are silently skipped (not emitted)
+  - The WhisperTokenizer requires file-based construction — created a synthetic test-tokenizer.json with 8 vocab tokens + 6 special tokens for fast, isolated testing
+  - Timestamp math: token 50364 + N → N * 0.02 seconds; token 50414 = exactly 1.00s (index 50)

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -27,6 +27,18 @@
 
 ## Learnings
 
+### 2025-07-15 - Timestamp Support (Issue #12)
+- Added `EnableTimestamps` option to `WhisperOptions` (default: false for backward compatibility)
+- Created `TranscriptionSegment` record type with `Start`, `End`, `Text` properties
+- Added `Segments` property (nullable `IReadOnlyList<TranscriptionSegment>`) to `TranscriptionResult`
+- Tokenizer changes: `IsTimestampToken()`, `GetTimestamp()`, `DecodeWithTimestamps()` methods; `NoTimestampsToken` property
+- Timestamp math: token 50364 = 0.00s, each subsequent ID adds 0.02s (`(tokenId - 50364) * 0.02`)
+- When timestamps enabled: omit `<|notimestamps|>` from initial sequence AND don't suppress timestamp tokens (IDs 50364+)
+- Extracted `BuildResult()` helper in `WhisperClient` to eliminate duplicated decode logic between file/stream overloads
+- `DecodeWithTimestamps` handles edge cases: trailing text with no end timestamp, empty segments, no timestamp tokens at all
+- All 112 existing unit tests continue to pass — zero behavioral change when `EnableTimestamps=false`
+- Key files: `WhisperOptions.cs`, `TranscriptionSegment.cs`, `TranscriptionResult.cs`, `WhisperTokenizer.cs`, `WhisperClient.cs`
+
 
 ### 2025-07-14 - Fix: use_cache_branch + KV Cache for Merged Decoder (Issue #1, summarized in Core Context)
 

--- a/.squad/decisions/inbox/ripley-timestamp-support.md
+++ b/.squad/decisions/inbox/ripley-timestamp-support.md
@@ -1,0 +1,27 @@
+# Decision: Timestamp Support Architecture (Issue #12)
+
+**Author:** Ripley (Backend Dev)
+**Date:** 2025-07-15
+**Status:** Implemented
+
+## Context
+Community member requested timestamp support for Whisper ONNX transcription. Previously all timestamp tokens (50364+) were suppressed.
+
+## Decision
+- **Opt-in via `WhisperOptions.EnableTimestamps`** (default false) — preserves backward compatibility
+- **No new inference logic** — timestamps are regular tokens the model generates when not suppressed
+- **`TranscriptionSegment` as a sealed record** — immutable, matches existing `TranscriptionResult` pattern
+- **Nullable `Segments` on `TranscriptionResult`** — null when timestamps disabled, populated list when enabled
+- **`BuildResult()` helper** extracted in `WhisperClient` to DRY up file/stream overloads
+
+## Rationale
+- Keeping timestamps opt-in means zero risk to existing users
+- Whisper natively produces timestamp pairs — we just need to stop suppressing them and parse the output
+- Sealed record for segment matches the library's immutability-first API style
+
+## Files Changed
+- `src/ElBruno.Whisper/WhisperOptions.cs` — added `EnableTimestamps`
+- `src/ElBruno.Whisper/TranscriptionSegment.cs` — new file
+- `src/ElBruno.Whisper/TranscriptionResult.cs` — added `Segments`
+- `src/ElBruno.Whisper/Tokenizer/WhisperTokenizer.cs` — timestamp methods + `NoTimestampsToken`
+- `src/ElBruno.Whisper/WhisperClient.cs` — conditional initial tokens, suppress tokens, BuildResult helper

--- a/src/ElBruno.Whisper/ElBruno.Whisper.csproj
+++ b/src/ElBruno.Whisper/ElBruno.Whisper.csproj
@@ -8,7 +8,7 @@
     <PackageIcon>nuget_logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>whisper;speech-to-text;stt;onnx;ai;local;audio;transcription;huggingface</PackageTags>
-    <Version>0.1.6</Version>
+    <Version>0.2.0</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>

--- a/src/ElBruno.Whisper/Tokenizer/WhisperTokenizer.cs
+++ b/src/ElBruno.Whisper/Tokenizer/WhisperTokenizer.cs
@@ -9,8 +9,20 @@ internal sealed class WhisperTokenizer
 {
     private readonly Dictionary<int, string> _idToToken = new();
     private readonly int _eotToken;
+    private readonly int _noTimestampsToken;
+
+    /// <summary>
+    /// The first timestamp token ID (noTimestamps + 1 = 50364).
+    /// Each subsequent ID represents an additional 0.02 seconds.
+    /// </summary>
+    private const double SecondsPerTimestampToken = 0.02;
 
     public int EotToken => _eotToken;
+
+    /// <summary>
+    /// Token ID for the &lt;|notimestamps|&gt; special token.
+    /// </summary>
+    public int NoTimestampsToken => _noTimestampsToken;
 
     public WhisperTokenizer(string tokenizerJsonPath)
     {
@@ -18,6 +30,7 @@ internal sealed class WhisperTokenizer
         
         // Common Whisper special tokens
         _eotToken = FindTokenId("<|endoftext|>") ?? 50257;
+        _noTimestampsToken = FindTokenId("<|notimestamps|>") ?? 50363;
     }
 
     private void LoadTokenizer(string path)
@@ -77,6 +90,104 @@ internal sealed class WhisperTokenizer
         text = text.Replace("Ġ", " "); // GPT-2 style space encoding
         text = text.Replace("Ċ", "\n"); // Newline encoding
         
+        return text.Trim();
+    }
+
+    /// <summary>
+    /// Returns true if the token ID is a timestamp token (>= noTimestamps + 1).
+    /// </summary>
+    public bool IsTimestampToken(int tokenId) => tokenId >= _noTimestampsToken + 1;
+
+    /// <summary>
+    /// Converts a timestamp token ID to its corresponding time offset.
+    /// Token 50364 = 0.00s, 50365 = 0.02s, etc.
+    /// </summary>
+    public TimeSpan GetTimestamp(int tokenId)
+    {
+        var index = tokenId - (_noTimestampsToken + 1);
+        return TimeSpan.FromSeconds(index * SecondsPerTimestampToken);
+    }
+
+    /// <summary>
+    /// Decodes token IDs into text and timestamped segments.
+    /// Timestamp tokens appear in pairs: start timestamp, text tokens, end timestamp.
+    /// </summary>
+    public (string Text, List<TranscriptionSegment> Segments) DecodeWithTimestamps(int[] tokenIds)
+    {
+        var segments = new List<TranscriptionSegment>();
+        var allTextTokens = new List<string>();
+
+        TimeSpan? pendingStart = null;
+        var currentSegmentTokens = new List<string>();
+
+        foreach (var id in tokenIds)
+        {
+            if (IsTimestampToken(id))
+            {
+                var ts = GetTimestamp(id);
+
+                if (pendingStart is null)
+                {
+                    // This is a start timestamp
+                    pendingStart = ts;
+                    currentSegmentTokens.Clear();
+                }
+                else
+                {
+                    // This is an end timestamp — emit segment
+                    var segmentText = DecodeTextTokens(currentSegmentTokens);
+                    if (!string.IsNullOrWhiteSpace(segmentText))
+                    {
+                        segments.Add(new TranscriptionSegment
+                        {
+                            Start = pendingStart.Value,
+                            End = ts,
+                            Text = segmentText
+                        });
+                    }
+
+                    pendingStart = null;
+                    currentSegmentTokens.Clear();
+                }
+            }
+            else if (_idToToken.TryGetValue(id, out var token))
+            {
+                // Skip non-timestamp special tokens
+                if (token.StartsWith("<|") && token.EndsWith("|>"))
+                    continue;
+
+                currentSegmentTokens.Add(token);
+                allTextTokens.Add(token);
+            }
+        }
+
+        // Handle trailing text tokens with a pending start but no end timestamp
+        if (pendingStart is not null && currentSegmentTokens.Count > 0)
+        {
+            var segmentText = DecodeTextTokens(currentSegmentTokens);
+            if (!string.IsNullOrWhiteSpace(segmentText))
+            {
+                segments.Add(new TranscriptionSegment
+                {
+                    Start = pendingStart.Value,
+                    End = pendingStart.Value,
+                    Text = segmentText
+                });
+            }
+        }
+
+        var fullText = DecodeTextTokens(allTextTokens);
+        return (fullText, segments);
+    }
+
+    /// <summary>
+    /// Joins raw BPE tokens and cleans up encoding artifacts.
+    /// </summary>
+    private static string DecodeTextTokens(List<string> tokens)
+    {
+        var text = string.Join("", tokens);
+        text = text.Replace("Ġ", " ");
+        text = text.Replace("Ċ", "\n");
         return text.Trim();
     }
 

--- a/src/ElBruno.Whisper/TranscriptionResult.cs
+++ b/src/ElBruno.Whisper/TranscriptionResult.cs
@@ -19,4 +19,9 @@ public sealed record TranscriptionResult
     /// Duration of the audio processed.
     /// </summary>
     public TimeSpan Duration { get; init; }
+
+    /// <summary>
+    /// Timestamped segments, if timestamp extraction was enabled.
+    /// </summary>
+    public IReadOnlyList<TranscriptionSegment>? Segments { get; init; }
 }

--- a/src/ElBruno.Whisper/TranscriptionSegment.cs
+++ b/src/ElBruno.Whisper/TranscriptionSegment.cs
@@ -1,0 +1,22 @@
+namespace ElBruno.Whisper;
+
+/// <summary>
+/// A timestamped segment of transcribed text.
+/// </summary>
+public sealed record TranscriptionSegment
+{
+    /// <summary>
+    /// Start time of the segment in the audio.
+    /// </summary>
+    public required TimeSpan Start { get; init; }
+
+    /// <summary>
+    /// End time of the segment in the audio.
+    /// </summary>
+    public required TimeSpan End { get; init; }
+
+    /// <summary>
+    /// The transcribed text for this segment.
+    /// </summary>
+    public required string Text { get; init; }
+}

--- a/src/ElBruno.Whisper/WhisperClient.cs
+++ b/src/ElBruno.Whisper/WhisperClient.cs
@@ -112,15 +112,7 @@ public sealed class WhisperClient : IDisposable
                 _beginSuppressTokens
             );
 
-            // Decode tokens
-            var text = _tokenizer.Decode(tokens);
-
-            return new TranscriptionResult
-            {
-                Text = text,
-                DetectedLanguage = _options.Language,
-                Duration = audioDuration
-            };
+            return BuildResult(tokens, audioDuration);
         }, cancellationToken);
     }
 
@@ -149,16 +141,30 @@ public sealed class WhisperClient : IDisposable
                 _beginSuppressTokens
             );
 
-            // Decode tokens
-            var text = _tokenizer.Decode(tokens);
+            return BuildResult(tokens, audioDuration);
+        }, cancellationToken);
+    }
 
+    private TranscriptionResult BuildResult(int[] tokens, TimeSpan audioDuration)
+    {
+        if (_options.EnableTimestamps)
+        {
+            var (text, segments) = _tokenizer.DecodeWithTimestamps(tokens);
             return new TranscriptionResult
             {
                 Text = text,
                 DetectedLanguage = _options.Language,
-                Duration = audioDuration
+                Duration = audioDuration,
+                Segments = segments
             };
-        }, cancellationToken);
+        }
+
+        return new TranscriptionResult
+        {
+            Text = _tokenizer.Decode(tokens),
+            DetectedLanguage = _options.Language,
+            Duration = audioDuration
+        };
     }
 
     private int[] GetInitialTokens()
@@ -177,8 +183,12 @@ public sealed class WhisperClient : IDisposable
             tokens.Add(_options.Translate ? translate : transcribe);
         }
 
-        // Add no-timestamps token
-        tokens.Add(noTimestamps);
+        // Skip no-timestamps token when timestamps are enabled so the model
+        // generates timestamp tokens in its output sequence.
+        if (!_options.EnableTimestamps)
+        {
+            tokens.Add(noTimestamps);
+        }
 
         return tokens.ToArray();
     }
@@ -192,12 +202,15 @@ public sealed class WhisperClient : IDisposable
     {
         var suppress = new HashSet<int>(_configSuppressTokens);
 
-        // Suppress timestamp tokens (all tokens from noTimestamps+1 onward)
-        var (_, _, _, noTimestamps, _) = _tokenizer.GetSpecialTokenIds();
-        const int vocabSize = 51865;
-        for (int t = noTimestamps + 1; t < vocabSize; t++)
+        // Only suppress timestamp tokens when timestamps are disabled
+        if (!_options.EnableTimestamps)
         {
-            suppress.Add(t);
+            var (_, _, _, noTimestamps, _) = _tokenizer.GetSpecialTokenIds();
+            const int vocabSize = 51865;
+            for (int t = noTimestamps + 1; t < vocabSize; t++)
+            {
+                suppress.Add(t);
+            }
         }
 
         return suppress.ToArray();

--- a/src/ElBruno.Whisper/WhisperOptions.cs
+++ b/src/ElBruno.Whisper/WhisperOptions.cs
@@ -44,4 +44,11 @@ public sealed class WhisperOptions
     /// Sampling temperature. 0.0 = greedy (deterministic), higher = more random.
     /// </summary>
     public float Temperature { get; set; } = 0.0f;
+
+    /// <summary>
+    /// If true, extract timestamp information from the model output.
+    /// Results will include <see cref="TranscriptionResult.Segments"/> with start/end times.
+    /// Defaults to false for backward compatibility.
+    /// </summary>
+    public bool EnableTimestamps { get; set; }
 }

--- a/src/tests/ElBruno.Whisper.Tests/ElBruno.Whisper.Tests.csproj
+++ b/src/tests/ElBruno.Whisper.Tests/ElBruno.Whisper.Tests.csproj
@@ -20,5 +20,9 @@
       <Link>TestData\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="..\..\..\testdata\tokenizer\*">
+      <Link>TestData\tokenizer\%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/src/tests/ElBruno.Whisper.Tests/Tokenizer/WhisperTokenizerTimestampTests.cs
+++ b/src/tests/ElBruno.Whisper.Tests/Tokenizer/WhisperTokenizerTimestampTests.cs
@@ -1,0 +1,351 @@
+using ElBruno.Whisper.Tokenizer;
+using Xunit;
+
+namespace ElBruno.Whisper.Tests.Tokenizer;
+
+public class WhisperTokenizerTimestampTests : IDisposable
+{
+    private readonly string _tokenizerPath;
+    private readonly WhisperTokenizer _tokenizer;
+
+    public WhisperTokenizerTimestampTests()
+    {
+        // Find the test tokenizer JSON relative to the test assembly
+        _tokenizerPath = FindTestTokenizerPath();
+        _tokenizer = new WhisperTokenizer(_tokenizerPath);
+    }
+
+    private static string FindTestTokenizerPath()
+    {
+        // Walk up from the test output directory to find testdata
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir, "testdata", "tokenizer", "test-tokenizer.json");
+            if (File.Exists(candidate))
+                return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new FileNotFoundException("Could not find testdata/tokenizer/test-tokenizer.json");
+    }
+
+    public void Dispose()
+    {
+        // No unmanaged resources to clean up
+        GC.SuppressFinalize(this);
+    }
+
+    // --- IsTimestampToken tests ---
+
+    [Fact]
+    public void IsTimestampToken_NoTimestampsToken_ReturnsFalse()
+    {
+        // 50363 is the <|notimestamps|> token itself, not a timestamp
+        Assert.False(_tokenizer.IsTimestampToken(50363));
+    }
+
+    [Fact]
+    public void IsTimestampToken_FirstTimestampToken_ReturnsTrue()
+    {
+        // 50364 is the first timestamp token (0.00s)
+        Assert.True(_tokenizer.IsTimestampToken(50364));
+    }
+
+    [Fact]
+    public void IsTimestampToken_SecondTimestampToken_ReturnsTrue()
+    {
+        Assert.True(_tokenizer.IsTimestampToken(50365));
+    }
+
+    [Fact]
+    public void IsTimestampToken_HighTimestampToken_ReturnsTrue()
+    {
+        // Token representing ~30 seconds
+        Assert.True(_tokenizer.IsTimestampToken(50364 + 1500));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(100)]
+    [InlineData(50257)]  // <|endoftext|>
+    [InlineData(50258)]  // <|startoftranscript|>
+    [InlineData(50359)]  // <|transcribe|>
+    [InlineData(50362)]
+    [InlineData(50363)]  // <|notimestamps|>
+    public void IsTimestampToken_NonTimestampIds_ReturnFalse(int tokenId)
+    {
+        Assert.False(_tokenizer.IsTimestampToken(tokenId));
+    }
+
+    [Theory]
+    [InlineData(50364)]
+    [InlineData(50365)]
+    [InlineData(50414)]
+    [InlineData(51000)]
+    public void IsTimestampToken_TimestampIds_ReturnTrue(int tokenId)
+    {
+        Assert.True(_tokenizer.IsTimestampToken(tokenId));
+    }
+
+    // --- GetTimestamp tests ---
+
+    [Fact]
+    public void GetTimestamp_FirstToken_ReturnsZero()
+    {
+        // 50364 → index 0 → 0.00s
+        var ts = _tokenizer.GetTimestamp(50364);
+
+        Assert.Equal(TimeSpan.Zero, ts);
+    }
+
+    [Fact]
+    public void GetTimestamp_SecondToken_Returns20ms()
+    {
+        // 50365 → index 1 → 0.02s
+        var ts = _tokenizer.GetTimestamp(50365);
+
+        Assert.Equal(TimeSpan.FromSeconds(0.02), ts);
+    }
+
+    [Fact]
+    public void GetTimestamp_Token50414_ReturnsOneSecond()
+    {
+        // 50414 → index 50 → 50 * 0.02 = 1.00s
+        var ts = _tokenizer.GetTimestamp(50414);
+
+        Assert.Equal(TimeSpan.FromSeconds(1.0), ts);
+    }
+
+    [Fact]
+    public void GetTimestamp_Token50464_ReturnsTwoSeconds()
+    {
+        // 50464 → index 100 → 100 * 0.02 = 2.00s
+        var ts = _tokenizer.GetTimestamp(50464);
+
+        Assert.Equal(TimeSpan.FromSeconds(2.0), ts);
+    }
+
+    [Fact]
+    public void GetTimestamp_Token51864_ReturnsThirtySeconds()
+    {
+        // 51864 → index 1500 → 1500 * 0.02 = 30.00s
+        var ts = _tokenizer.GetTimestamp(51864);
+
+        Assert.Equal(TimeSpan.FromSeconds(30.0), ts);
+    }
+
+    [Theory]
+    [InlineData(50364, 0.0)]
+    [InlineData(50365, 0.02)]
+    [InlineData(50374, 0.20)]
+    [InlineData(50414, 1.00)]
+    [InlineData(50464, 2.00)]
+    [InlineData(50514, 3.00)]
+    public void GetTimestamp_KnownValues_ReturnsExpectedSeconds(int tokenId, double expectedSeconds)
+    {
+        var ts = _tokenizer.GetTimestamp(tokenId);
+
+        Assert.Equal(expectedSeconds, ts.TotalSeconds, precision: 10);
+    }
+
+    // --- NoTimestampsToken property ---
+
+    [Fact]
+    public void NoTimestampsToken_ReturnsExpectedValue()
+    {
+        Assert.Equal(50363, _tokenizer.NoTimestampsToken);
+    }
+
+    // --- DecodeWithTimestamps tests ---
+
+    [Fact]
+    public void DecodeWithTimestamps_EmptyTokens_ReturnsEmptyResult()
+    {
+        var (text, segments) = _tokenizer.DecodeWithTimestamps(Array.Empty<int>());
+
+        Assert.Equal(string.Empty, text);
+        Assert.Empty(segments);
+    }
+
+    [Fact]
+    public void DecodeWithTimestamps_SingleSegment_ReturnsOneSegment()
+    {
+        // <0.00s> Hello world <1.00s>
+        var tokenIds = new[]
+        {
+            50364,  // timestamp 0.00s
+            31373,  // ĠHello
+            995,    // Ġworld
+            50414   // timestamp 1.00s
+        };
+
+        var (text, segments) = _tokenizer.DecodeWithTimestamps(tokenIds);
+
+        Assert.Equal("Hello world", text);
+        Assert.Single(segments);
+        Assert.Equal(TimeSpan.FromSeconds(0.0), segments[0].Start);
+        Assert.Equal(TimeSpan.FromSeconds(1.0), segments[0].End);
+        Assert.Equal("Hello world", segments[0].Text);
+    }
+
+    [Fact]
+    public void DecodeWithTimestamps_TwoSegments_ReturnsBoth()
+    {
+        // <0.00s> Hello <1.00s> <1.00s> world <2.00s>
+        var tokenIds = new[]
+        {
+            50364,  // timestamp 0.00s
+            31373,  // ĠHello
+            50414,  // timestamp 1.00s
+            50414,  // timestamp 1.00s (start of second segment)
+            995,    // Ġworld
+            50464   // timestamp 2.00s
+        };
+
+        var (text, segments) = _tokenizer.DecodeWithTimestamps(tokenIds);
+
+        Assert.Equal("Hello world", text);
+        Assert.Equal(2, segments.Count);
+
+        Assert.Equal(TimeSpan.FromSeconds(0.0), segments[0].Start);
+        Assert.Equal(TimeSpan.FromSeconds(1.0), segments[0].End);
+        Assert.Equal("Hello", segments[0].Text);
+
+        Assert.Equal(TimeSpan.FromSeconds(1.0), segments[1].Start);
+        Assert.Equal(TimeSpan.FromSeconds(2.0), segments[1].End);
+        Assert.Equal("world", segments[1].Text);
+    }
+
+    [Fact]
+    public void DecodeWithTimestamps_SkipsSpecialTokens()
+    {
+        // SOT <0.00s> Hello <1.00s> EOT
+        var tokenIds = new[]
+        {
+            50258,  // <|startoftranscript|>
+            50364,  // timestamp 0.00s
+            31373,  // ĠHello
+            50414,  // timestamp 1.00s
+            50257   // <|endoftext|>
+        };
+
+        var (text, segments) = _tokenizer.DecodeWithTimestamps(tokenIds);
+
+        Assert.Equal("Hello", text);
+        Assert.Single(segments);
+        Assert.Equal("Hello", segments[0].Text);
+    }
+
+    [Fact]
+    public void DecodeWithTimestamps_TextWithNoTimestamps_ReturnsEmptySegments()
+    {
+        // Just text tokens, no timestamps
+        var tokenIds = new[]
+        {
+            31373,  // ĠHello
+            995     // Ġworld
+        };
+
+        var (text, segments) = _tokenizer.DecodeWithTimestamps(tokenIds);
+
+        Assert.Equal("Hello world", text);
+        Assert.Empty(segments);
+    }
+
+    [Fact]
+    public void DecodeWithTimestamps_TrailingTextAfterStartTimestamp_EmitsSegment()
+    {
+        // <0.00s> Hello (no end timestamp)
+        var tokenIds = new[]
+        {
+            50364,  // timestamp 0.00s
+            31373   // ĠHello
+        };
+
+        var (text, segments) = _tokenizer.DecodeWithTimestamps(tokenIds);
+
+        Assert.Equal("Hello", text);
+        Assert.Single(segments);
+        // Trailing segments use the start time as the end time
+        Assert.Equal(TimeSpan.FromSeconds(0.0), segments[0].Start);
+        Assert.Equal(TimeSpan.FromSeconds(0.0), segments[0].End);
+        Assert.Equal("Hello", segments[0].Text);
+    }
+
+    [Fact]
+    public void DecodeWithTimestamps_WhitespaceOnlySegment_IsSkipped()
+    {
+        // <0.00s> <1.00s> — empty segment between timestamps should be skipped
+        var tokenIds = new[]
+        {
+            50364,  // timestamp 0.00s
+            50414   // timestamp 1.00s (end of empty segment)
+        };
+
+        var (text, segments) = _tokenizer.DecodeWithTimestamps(tokenIds);
+
+        Assert.Equal(string.Empty, text);
+        Assert.Empty(segments);
+    }
+
+    [Fact]
+    public void DecodeWithTimestamps_MultipleTokensInSegment_ConcatenatesText()
+    {
+        // <0.00s> This is a test <2.00s>
+        var tokenIds = new[]
+        {
+            50364,  // timestamp 0.00s
+            770,    // ĠThis
+            318,    // Ġis
+            257,    // Ġa
+            1332,   // Ġtest
+            50464   // timestamp 2.00s
+        };
+
+        var (text, segments) = _tokenizer.DecodeWithTimestamps(tokenIds);
+
+        Assert.Equal("This is a test", text);
+        Assert.Single(segments);
+        Assert.Equal("This is a test", segments[0].Text);
+        Assert.Equal(TimeSpan.FromSeconds(0.0), segments[0].Start);
+        Assert.Equal(TimeSpan.FromSeconds(2.0), segments[0].End);
+    }
+
+    [Fact]
+    public void DecodeWithTimestamps_FullTranscriptSequence_ExtractsAllSegments()
+    {
+        // Simulates a real Whisper output:
+        // SOT en transcribe <0.00s> Hello world <1.00s> <1.00s> This is a test <2.00s> EOT
+        var tokenIds = new[]
+        {
+            50258,  // <|startoftranscript|>
+            50259,  // <|en|>
+            50359,  // <|transcribe|>
+            50364,  // timestamp 0.00s
+            31373,  // ĠHello
+            995,    // Ġworld
+            50414,  // timestamp 1.00s
+            50414,  // timestamp 1.00s (start of segment 2)
+            770,    // ĠThis
+            318,    // Ġis
+            257,    // Ġa
+            1332,   // Ġtest
+            50464,  // timestamp 2.00s
+            50257   // <|endoftext|>
+        };
+
+        var (text, segments) = _tokenizer.DecodeWithTimestamps(tokenIds);
+
+        Assert.Equal("Hello world This is a test", text);
+        Assert.Equal(2, segments.Count);
+
+        Assert.Equal(TimeSpan.FromSeconds(0.0), segments[0].Start);
+        Assert.Equal(TimeSpan.FromSeconds(1.0), segments[0].End);
+        Assert.Equal("Hello world", segments[0].Text);
+
+        Assert.Equal(TimeSpan.FromSeconds(1.0), segments[1].Start);
+        Assert.Equal(TimeSpan.FromSeconds(2.0), segments[1].End);
+        Assert.Equal("This is a test", segments[1].Text);
+    }
+}

--- a/src/tests/ElBruno.Whisper.Tests/TranscriptionResultTests.cs
+++ b/src/tests/ElBruno.Whisper.Tests/TranscriptionResultTests.cs
@@ -123,4 +123,125 @@ public class TranscriptionResultTests
 
         Assert.Equal(longDuration, result.Duration);
     }
+
+    [Fact]
+    public void DefaultSegments_ShouldBeNull()
+    {
+        var result = new TranscriptionResult
+        {
+            Text = "Hello"
+        };
+
+        Assert.Null(result.Segments);
+    }
+
+    [Fact]
+    public void CanSetSegments()
+    {
+        var segments = new List<TranscriptionSegment>
+        {
+            new()
+            {
+                Start = TimeSpan.FromSeconds(0),
+                End = TimeSpan.FromSeconds(1),
+                Text = "Hello"
+            },
+            new()
+            {
+                Start = TimeSpan.FromSeconds(1),
+                End = TimeSpan.FromSeconds(2),
+                Text = "world"
+            }
+        };
+
+        var result = new TranscriptionResult
+        {
+            Text = "Hello world",
+            Segments = segments
+        };
+
+        Assert.NotNull(result.Segments);
+        Assert.Equal(2, result.Segments.Count);
+        Assert.Equal("Hello", result.Segments[0].Text);
+        Assert.Equal("world", result.Segments[1].Text);
+    }
+
+    [Fact]
+    public void Segments_CanBeEmptyList()
+    {
+        var result = new TranscriptionResult
+        {
+            Text = "Hello",
+            Segments = new List<TranscriptionSegment>()
+        };
+
+        Assert.NotNull(result.Segments);
+        Assert.Empty(result.Segments);
+    }
+
+    [Fact]
+    public void Segments_EmptyListIsNotNull()
+    {
+        var result = new TranscriptionResult
+        {
+            Text = "Hello",
+            Segments = new List<TranscriptionSegment>()
+        };
+
+        Assert.NotNull(result.Segments);
+    }
+
+    [Fact]
+    public void Segments_IsReadOnlyList()
+    {
+        var segments = new List<TranscriptionSegment>
+        {
+            new()
+            {
+                Start = TimeSpan.Zero,
+                End = TimeSpan.FromSeconds(1),
+                Text = "Test"
+            }
+        };
+
+        var result = new TranscriptionResult
+        {
+            Text = "Test",
+            Segments = segments
+        };
+
+        Assert.IsAssignableFrom<IReadOnlyList<TranscriptionSegment>>(result.Segments);
+    }
+
+    [Fact]
+    public void Segments_WithTimestampData_HasCorrectTimes()
+    {
+        var segments = new List<TranscriptionSegment>
+        {
+            new()
+            {
+                Start = TimeSpan.FromSeconds(0.0),
+                End = TimeSpan.FromSeconds(2.5),
+                Text = "First segment"
+            },
+            new()
+            {
+                Start = TimeSpan.FromSeconds(2.5),
+                End = TimeSpan.FromSeconds(5.0),
+                Text = "Second segment"
+            }
+        };
+
+        var result = new TranscriptionResult
+        {
+            Text = "First segment Second segment",
+            Duration = TimeSpan.FromSeconds(5.0),
+            Segments = segments
+        };
+
+        Assert.Equal(TimeSpan.FromSeconds(0.0), result.Segments![0].Start);
+        Assert.Equal(TimeSpan.FromSeconds(2.5), result.Segments[0].End);
+        Assert.Equal(TimeSpan.FromSeconds(2.5), result.Segments[1].Start);
+        Assert.Equal(TimeSpan.FromSeconds(5.0), result.Segments[1].End);
+    }
 }

--- a/src/tests/ElBruno.Whisper.Tests/TranscriptionSegmentTests.cs
+++ b/src/tests/ElBruno.Whisper.Tests/TranscriptionSegmentTests.cs
@@ -1,0 +1,224 @@
+using Xunit;
+
+namespace ElBruno.Whisper.Tests;
+
+public class TranscriptionSegmentTests
+{
+    [Fact]
+    public void TranscriptionSegment_HasStartProperty()
+    {
+        var segment = new TranscriptionSegment
+        {
+            Start = TimeSpan.FromSeconds(1.5),
+            End = TimeSpan.FromSeconds(3.0),
+            Text = "Hello"
+        };
+
+        Assert.Equal(TimeSpan.FromSeconds(1.5), segment.Start);
+    }
+
+    [Fact]
+    public void TranscriptionSegment_HasEndProperty()
+    {
+        var segment = new TranscriptionSegment
+        {
+            Start = TimeSpan.FromSeconds(0),
+            End = TimeSpan.FromSeconds(2.5),
+            Text = "Hello"
+        };
+
+        Assert.Equal(TimeSpan.FromSeconds(2.5), segment.End);
+    }
+
+    [Fact]
+    public void TranscriptionSegment_HasTextProperty()
+    {
+        var segment = new TranscriptionSegment
+        {
+            Start = TimeSpan.Zero,
+            End = TimeSpan.FromSeconds(1),
+            Text = "test text"
+        };
+
+        Assert.Equal("test text", segment.Text);
+    }
+
+    [Fact]
+    public void TranscriptionSegment_WithZeroTimeSpans()
+    {
+        var segment = new TranscriptionSegment
+        {
+            Start = TimeSpan.Zero,
+            End = TimeSpan.Zero,
+            Text = "instant"
+        };
+
+        Assert.Equal(TimeSpan.Zero, segment.Start);
+        Assert.Equal(TimeSpan.Zero, segment.End);
+    }
+
+    [Fact]
+    public void TranscriptionSegment_WithLargeTimeSpans()
+    {
+        var start = TimeSpan.FromHours(1);
+        var end = TimeSpan.FromHours(1.5);
+        var segment = new TranscriptionSegment
+        {
+            Start = start,
+            End = end,
+            Text = "long audio"
+        };
+
+        Assert.Equal(start, segment.Start);
+        Assert.Equal(end, segment.End);
+    }
+
+    [Fact]
+    public void TranscriptionSegment_WithMillisecondPrecision()
+    {
+        var start = TimeSpan.FromMilliseconds(1234);
+        var end = TimeSpan.FromMilliseconds(5678);
+        var segment = new TranscriptionSegment
+        {
+            Start = start,
+            End = end,
+            Text = "precise"
+        };
+
+        Assert.Equal(1234, segment.Start.TotalMilliseconds);
+        Assert.Equal(5678, segment.End.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void TranscriptionSegment_IsRecord_SupportsEquality()
+    {
+        var segment1 = new TranscriptionSegment
+        {
+            Start = TimeSpan.FromSeconds(1),
+            End = TimeSpan.FromSeconds(2),
+            Text = "Hello"
+        };
+
+        var segment2 = new TranscriptionSegment
+        {
+            Start = TimeSpan.FromSeconds(1),
+            End = TimeSpan.FromSeconds(2),
+            Text = "Hello"
+        };
+
+        Assert.Equal(segment1, segment2);
+    }
+
+    [Fact]
+    public void TranscriptionSegment_IsRecord_DifferentValues_NotEqual()
+    {
+        var segment1 = new TranscriptionSegment
+        {
+            Start = TimeSpan.FromSeconds(1),
+            End = TimeSpan.FromSeconds(2),
+            Text = "Hello"
+        };
+
+        var segment2 = new TranscriptionSegment
+        {
+            Start = TimeSpan.FromSeconds(1),
+            End = TimeSpan.FromSeconds(3),
+            Text = "Hello"
+        };
+
+        Assert.NotEqual(segment1, segment2);
+    }
+
+    [Fact]
+    public void TranscriptionSegment_IsRecord_DifferentText_NotEqual()
+    {
+        var segment1 = new TranscriptionSegment
+        {
+            Start = TimeSpan.FromSeconds(0),
+            End = TimeSpan.FromSeconds(1),
+            Text = "Hello"
+        };
+
+        var segment2 = new TranscriptionSegment
+        {
+            Start = TimeSpan.FromSeconds(0),
+            End = TimeSpan.FromSeconds(1),
+            Text = "World"
+        };
+
+        Assert.NotEqual(segment1, segment2);
+    }
+
+    [Fact]
+    public void TranscriptionSegment_IsRecord_SupportsHashCode()
+    {
+        var segment1 = new TranscriptionSegment
+        {
+            Start = TimeSpan.FromSeconds(1),
+            End = TimeSpan.FromSeconds(2),
+            Text = "Hello"
+        };
+
+        var segment2 = new TranscriptionSegment
+        {
+            Start = TimeSpan.FromSeconds(1),
+            End = TimeSpan.FromSeconds(2),
+            Text = "Hello"
+        };
+
+        Assert.Equal(segment1.GetHashCode(), segment2.GetHashCode());
+    }
+
+    [Fact]
+    public void TranscriptionSegment_IsRecord_SupportsToString()
+    {
+        var segment = new TranscriptionSegment
+        {
+            Start = TimeSpan.FromSeconds(1),
+            End = TimeSpan.FromSeconds(2),
+            Text = "Hello"
+        };
+
+        var str = segment.ToString();
+
+        Assert.Contains("Hello", str);
+        Assert.Contains("Start", str);
+        Assert.Contains("End", str);
+    }
+
+    [Fact]
+    public void TranscriptionSegment_IsSealed()
+    {
+        Assert.True(typeof(TranscriptionSegment).IsSealed);
+    }
+
+    [Fact]
+    public void TranscriptionSegment_IsRecord_CanUseWith()
+    {
+        var original = new TranscriptionSegment
+        {
+            Start = TimeSpan.FromSeconds(1),
+            End = TimeSpan.FromSeconds(2),
+            Text = "Hello"
+        };
+
+        var modified = original with { Text = "World" };
+
+        Assert.Equal("World", modified.Text);
+        Assert.Equal(original.Start, modified.Start);
+        Assert.Equal(original.End, modified.End);
+    }
+
+    [Fact]
+    public void TranscriptionSegment_EmptyText()
+    {
+        var segment = new TranscriptionSegment
+        {
+            Start = TimeSpan.Zero,
+            End = TimeSpan.FromSeconds(1),
+            Text = string.Empty
+        };
+
+        Assert.Equal(string.Empty, segment.Text);
+    }
+}

--- a/src/tests/ElBruno.Whisper.Tests/WhisperOptionsTests.cs
+++ b/src/tests/ElBruno.Whisper.Tests/WhisperOptionsTests.cs
@@ -138,4 +138,35 @@ public class WhisperOptionsTests
         
         Assert.True(options.Translate);
     }
+
+    [Fact]
+    public void DefaultEnableTimestamps_ShouldBeFalse()
+    {
+        var options = new WhisperOptions();
+
+        Assert.False(options.EnableTimestamps);
+    }
+
+    [Fact]
+    public void CanSetEnableTimestamps()
+    {
+        var options = new WhisperOptions
+        {
+            EnableTimestamps = true
+        };
+
+        Assert.True(options.EnableTimestamps);
+    }
+
+    [Fact]
+    public void EnableTimestamps_CanBeToggledBackToFalse()
+    {
+        var options = new WhisperOptions
+        {
+            EnableTimestamps = true
+        };
+        options.EnableTimestamps = false;
+
+        Assert.False(options.EnableTimestamps);
+    }
 }


### PR DESCRIPTION
## Summary

Adds optional timestamp extraction to Whisper transcription, addressing [Issue #12](https://github.com/elbruno/ElBruno.Whisper/issues/12).

## Changes

### New API
- **`WhisperOptions.EnableTimestamps`** — opt-in bool (default false), enables timestamp extraction
- **`TranscriptionSegment`** — new sealed record with `Start`, `End` (TimeSpan), and `Text` properties
- **`TranscriptionResult.Segments`** — optional `IReadOnlyList<TranscriptionSegment>?` populated when timestamps enabled

### Core Changes
- **WhisperTokenizer**: Added `IsTimestampToken()`, `GetTimestamp()`, `DecodeWithTimestamps()` methods and `NoTimestampsToken` property
- **WhisperClient**: Conditionally omits `<|notimestamps|>` from initial sequence and stops suppressing timestamp tokens (IDs 50364+) when `EnableTimestamps=true`

### Tests
- 59 new unit tests covering all timestamp functionality
- All 171 tests pass (112 existing + 59 new)

### Backward Compatibility
Default behavior (`EnableTimestamps=false`) is **completely unchanged**. All existing tests pass without modification.

## Usage

```csharp
var options = new WhisperOptions { EnableTimestamps = true };
var client = await WhisperClient.CreateAsync(options);
var result = await client.TranscribeAsync("audio.wav");

foreach (var segment in result.Segments!)
{
    Console.WriteLine($"[{segment.Start} -> {segment.End}] {segment.Text}");
}
```

Closes #12